### PR TITLE
Update name/localStorage and default times

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,10 +48,15 @@ def index():
 
 @app.route('/add', methods=['POST'])
 def add():
+    today = datetime.now().strftime('%Y-%m-%d')
     row = [
-        request.form['name'], request.form['email'], request.form['date'],
-        request.form['from_time'], request.form['to_time'],
-        request.form['task'], request.form['description']
+        request.form['name'],
+        request.form['email'],
+        today,
+        request.form['from_time'],
+        request.form['to_time'],
+        request.form['task'],
+        request.form['description']
     ]
     with open(CSV_FILE, 'a', newline='') as file:
         writer = csv.writer(file)

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,6 @@
         <div class="modal-body">
             <input name="name" class="form-control mb-2" placeholder="Your Name" required>
             <input name="email" type="email" class="form-control mb-2" placeholder="Official Email" required>
-            <input name="date" type="date" class="form-control mb-2" required>
             <input name="from_time" type="time" class="form-control mb-2" required>
             <input name="to_time" type="time" class="form-control mb-2" required>
             <input name="task" class="form-control mb-2" placeholder="Task Name" required>
@@ -52,5 +51,35 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const nameField = document.querySelector('input[name="name"]');
+    let storedName = localStorage.getItem('name');
+    if (!storedName) {
+        storedName = prompt('Please enter your name:');
+        if (storedName) {
+            localStorage.setItem('name', storedName);
+        }
+    }
+    if (storedName && nameField) {
+        nameField.value = storedName;
+    }
+
+    const fromField = document.querySelector('input[name="from_time"]');
+    const toField = document.querySelector('input[name="to_time"]');
+    const modal = document.getElementById('addTimeModal');
+    const setCurrentTime = () => {
+        const now = new Date();
+        const timeString = now.toISOString().slice(11, 16);
+        if (fromField) fromField.value = timeString;
+        if (toField) toField.value = timeString;
+    };
+    if (modal) {
+        modal.addEventListener('show.bs.modal', setCurrentTime);
+    } else {
+        setCurrentTime();
+    }
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- auto-fill date on backend and remove field from modal
- remember name using localStorage and prompt
- set default time inputs to current time when modal opens

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b8c0b1a208328ab3d6910e04624db