### PR TITLE
Improve UI and local timezone defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ CSV_FILE = 'time_log.csv'
 if not os.path.exists(CSV_FILE):
     with open(CSV_FILE, 'w', newline='') as file:
         writer = csv.writer(file)
-        writer.writerow(['Name', 'Email', 'Date', 'From Time', 'To Time', 'Task', 'Description'])
+        writer.writerow(['Name', 'Date', 'From Time', 'To Time', 'Task', 'Description'])
 
 def _read_entries():
     entries = []
@@ -48,10 +48,9 @@ def index():
 
 @app.route('/add', methods=['POST'])
 def add():
-    today = datetime.now().strftime('%Y-%m-%d')
+    today = request.form.get('date') or datetime.now().strftime('%Y-%m-%d')
     row = [
         request.form['name'],
-        request.form['email'],
         today,
         request.form['from_time'],
         request.form['to_time'],

--- a/static/style.css
+++ b/static/style.css
@@ -3,6 +3,19 @@ body {
     font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
+.navbar {
+    background-color: #7b68ee !important;
+}
+
+.btn-primary {
+    background-color: #7b68ee;
+    border-color: #7b68ee;
+}
+.btn-primary:hover {
+    background-color: #6a57d5;
+    border-color: #6a57d5;
+}
+
 .navbar-brand img {
     height: 40px;
     margin-right: 10px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Time Tracker</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/pulse/bootstrap.min.css">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -43,7 +43,7 @@
         <div class="modal-header"><h5 class="modal-title">Add Time Entry</h5></div>
         <div class="modal-body">
             <input name="name" class="form-control mb-2" placeholder="Your Name" required>
-            <input name="email" type="email" class="form-control mb-2" placeholder="Official Email" required>
+            <input type="hidden" name="date">
             <input name="from_time" type="time" class="form-control mb-2" required>
             <input name="to_time" type="time" class="form-control mb-2" required>
             <input name="task" class="form-control mb-2" placeholder="Task Name" required>
@@ -79,12 +79,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const fromField = document.querySelector('input[name="from_time"]');
     const toField = document.querySelector('input[name="to_time"]');
+    const dateField = document.querySelector('input[name="date"]');
     const modal = document.getElementById('addTimeModal');
     const setCurrentTime = () => {
         const now = new Date();
-        const timeString = now.toISOString().slice(11, 16);
+        const pad = n => n.toString().padStart(2, '0');
+        const timeString = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+        const dateString = now.toLocaleDateString('en-CA');
         if (fromField) fromField.value = timeString;
         if (toField) toField.value = timeString;
+        if (dateField) dateField.value = dateString;
     };
     if (modal) {
         modal.addEventListener('show.bs.modal', setCurrentTime);

--- a/templates/report.html
+++ b/templates/report.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Weekly Report</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/pulse/bootstrap.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>

--- a/time_log.csv
+++ b/time_log.csv
@@ -1,1 +1,1 @@
-Name,Email,Date,From Time,To Time,Task,Description
+Name,Date,From Time,To Time,Task,Description


### PR DESCRIPTION
## Summary
- adjust UI colors and bootstrap theme to mimic ClickUp's purple look
- remove email field from the time entry form and CSV
- store client-side local date and time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b8ecec2f88328a7c7803853eba66a