### PR TITLE
Dynamic entry form with uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,4 +204,6 @@ cython_debug/
 # Marimo
 marimo/_static/
 marimo/_lsp/
-__marimo__/
+
+# Uploaded files
+uploads/

--- a/app.py
+++ b/app.py
@@ -1,17 +1,40 @@
 import csv
 import os
-from datetime import datetime
+import re
+import time
+from datetime import datetime, timedelta
 from collections import defaultdict
-from flask import Flask, render_template, request, redirect, url_for, flash, send_file, jsonify
+from flask import (
+    Flask,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    send_file,
+    jsonify,
+    send_from_directory,
+)
+from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
 app.secret_key = 'secret123'
 CSV_FILE = 'time_log.csv'
+UPLOAD_FOLDER = 'uploads'
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 if not os.path.exists(CSV_FILE):
     with open(CSV_FILE, 'w', newline='') as file:
         writer = csv.writer(file)
-        writer.writerow(['Name', 'Date', 'From Time', 'To Time', 'Task', 'Description'])
+        writer.writerow([
+            'Name',
+            'Date',
+            'From Time',
+            'To Time',
+            'Task',
+            'Description',
+            'File',
+        ])
 
 def _read_entries():
     entries = []
@@ -26,40 +49,76 @@ def _hours(from_t, to_t):
     fmt = '%H:%M'
     return (datetime.strptime(to_t, fmt) - datetime.strptime(from_t, fmt)).seconds / 3600
 
-def _daily_summary(entries):
-    summary = defaultdict(float)
-    for row in entries:
-        key = (row['Name'], row['Date'])
-        summary[key] += _hours(row['From Time'], row['To Time'])
-    return [{'Name': k[0], 'Date': k[1], 'Hours': v} for k, v in summary.items()]
+def _format_date(date_str, show_year=False):
+    dt = datetime.strptime(date_str, '%Y-%m-%d')
+    return dt.strftime('%m/%d/%Y' if show_year else '%m/%d')
+
+@app.template_filter('linkify')
+def _linkify(text):
+    url_pattern = r'(https?://[\w\.-/]+)'
+    return re.sub(url_pattern, r'<a href="\1" target="_blank">\1</a>', text)
 
 def _weekly_summary(entries):
     weekly = defaultdict(lambda: defaultdict(float))
     for row in entries:
         dt = datetime.strptime(row['Date'], '%Y-%m-%d')
-        week = f"{dt.isocalendar().year}-W{dt.isocalendar().week:02d}"
-        weekly[week][row['Name']] += _hours(row['From Time'], row['To Time'])
+        week_start = dt - timedelta(days=dt.weekday())
+        key = week_start.strftime('%Y-%m-%d')
+        weekly[key][row['Name']] += _hours(row['From Time'], row['To Time'])
     return weekly
+
 
 @app.route('/')
 def index():
-    data = _daily_summary(_read_entries())
-    return render_template('index.html', data=data)
+    entries = _read_entries()
+    years = {datetime.strptime(e['Date'], '%Y-%m-%d').year for e in entries}
+    show_year = any(year != 2025 for year in years)
+    for e in entries:
+        e['hours'] = _hours(e['From Time'], e['To Time'])
+        e['date_display'] = _format_date(e['Date'], show_year)
+    return render_template('index.html', data=entries, show_year=show_year)
 
 @app.route('/add', methods=['POST'])
 def add():
     today = request.form.get('date') or datetime.now().strftime('%Y-%m-%d')
+    uploaded = request.files.get('file')
+    filename = ''
+    if uploaded and uploaded.filename:
+        safe = secure_filename(uploaded.filename)
+        fname = f"{int(time.time())}_{safe}"
+        path = os.path.join(UPLOAD_FOLDER, fname)
+        uploaded.save(path)
+        filename = fname
     row = [
         request.form['name'],
         today,
         request.form['from_time'],
         request.form['to_time'],
         request.form['task'],
-        request.form['description']
+        request.form.get('description', ''),
+        filename,
     ]
     with open(CSV_FILE, 'a', newline='') as file:
         writer = csv.writer(file)
         writer.writerow(row)
+
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        hours = _hours(row[2], row[3])
+        years = {datetime.strptime(r['Date'], '%Y-%m-%d').year for r in _read_entries()}
+        show_year = any(y != 2025 for y in years)
+        return jsonify(
+            {
+                'name': row[0],
+                'date_display': _format_date(row[1], show_year),
+                'from_time': row[2],
+                'to_time': row[3],
+                'hours': hours,
+                'task': row[4],
+                'description_html': _linkify(row[5]),
+                'file_link': f'<a href="/uploads/{filename}" download target="_blank">{filename}</a>' if filename else '',
+            }
+        )
+
     flash('Time entry added successfully')
     return redirect(url_for('index'))
 
@@ -71,26 +130,59 @@ def report():
 def weekly_data():
     weekly = _weekly_summary(_read_entries())
     weeks = sorted(weekly.keys())
+    years = {datetime.strptime(w, '%Y-%m-%d').year for w in weeks}
+    show_year = any(y != 2025 for y in years)
+    labels = [_format_date(w, show_year) for w in weeks]
     names = sorted({name for w in weekly.values() for name in w.keys()})
     hours = {name: [weekly[w].get(name, 0) for w in weeks] for name in names}
-    return jsonify({'weeks': weeks, 'names': names, 'hours': hours})
+    return jsonify({'weeks': labels, 'names': names, 'hours': hours})
 
 @app.route('/download')
 def download():
-    return send_file(CSV_FILE, as_attachment=True)
+    entries = _read_entries()
+    file = 'entries.csv'
+    with open(file, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            'Date',
+            'From Time',
+            'To Time',
+            'Hours',
+            'Task',
+            'Description',
+            'File',
+        ])
+        for e in entries:
+            writer.writerow([
+                e['Date'],
+                e['From Time'],
+                e['To Time'],
+                round(_hours(e['From Time'], e['To Time']), 2),
+                e['Task'],
+                e['Description'],
+                e['File'],
+            ])
+    return send_file(file, as_attachment=True)
 
 @app.route('/weekly-download')
 def weekly_download():
     weekly = _weekly_summary(_read_entries())
     weeks = sorted(weekly.keys())
+    years = {datetime.strptime(w, '%Y-%m-%d').year for w in weeks}
+    show_year = any(y != 2025 for y in years)
+    labels = [_format_date(w, show_year) for w in weeks]
     names = sorted({name for w in weekly.values() for name in w.keys()})
     file = 'weekly_report.csv'
     with open(file, 'w', newline='') as f:
         writer = csv.writer(f)
         writer.writerow(['Week'] + names)
-        for week in weeks:
-            writer.writerow([week] + [weekly[week].get(name, 0) for name in names])
+        for week, label in zip(weeks, labels):
+            writer.writerow([label] + [weekly[week].get(name, 0) for name in names])
     return send_file(file, as_attachment=True)
+
+@app.route('/uploads/<path:filename>')
+def uploaded(filename):
+    return send_from_directory(UPLOAD_FOLDER, filename, as_attachment=True)
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,86 +15,98 @@
         <div class="ms-auto">
             <a href="/download" class="btn btn-outline-light me-2">Download CSV</a>
             <a href="/report" class="btn btn-outline-light me-2">Weekly Report</a>
-            <button class="btn btn-light" data-bs-toggle="modal" data-bs-target="#addTimeModal">Add Time</button>
         </div>
     </div>
 </nav>
 
 <div class="container mt-4">
+    <form id="entry-form" class="row g-2 mb-3" enctype="multipart/form-data">
+        <div class="col-md-2"><input name="name" class="form-control" placeholder="Name" required></div>
+        <div class="col-md-2"><input name="date" type="date" class="form-control" required></div>
+        <div class="col-md-1"><input name="from_time" type="time" class="form-control" required></div>
+        <div class="col-md-1"><input name="to_time" type="time" class="form-control" required></div>
+        <div class="col-md-2"><input name="task" class="form-control" placeholder="Task" required></div>
+        <div class="col-md-3">
+            <textarea name="description" class="form-control" placeholder="Description" rows="1"></textarea>
+            <input type="file" name="file" class="form-control mt-1">
+        </div>
+        <div class="col-md-1 d-grid"><button type="submit" class="btn btn-primary">Add</button></div>
+    </form>
+
     <table class="table table-bordered table-striped">
-        <thead><tr><th>Name</th><th>Date</th><th>Hours</th></tr></thead>
-        <tbody>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Date</th>
+                <th>Start</th>
+                <th>End</th>
+                <th>Hours</th>
+                <th>Task</th>
+                <th>Description</th>
+                <th>File</th>
+            </tr>
+        </thead>
+        <tbody id="entry-body">
         {% for row in data %}
             <tr>
                 <td>{{ row['Name'] }}</td>
-                <td>{{ row['Date'] }}</td>
-                <td>{{ row['Hours'] | round(2) }}</td>
+                <td>{{ row.date_display }}</td>
+                <td>{{ row['From Time'] }}</td>
+                <td>{{ row['To Time'] }}</td>
+                <td>{{ row.hours | round(2) }}</td>
+                <td>{{ row['Task'] }}</td>
+                <td>{{ row['Description']|linkify|safe }}</td>
+                <td>{% if row['File'] %}<a href="/uploads/{{ row['File'] }}" target="_blank" download>{{ row['File'] }}</a>{% endif %}</td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
 </div>
 
-<!-- Modal -->
-<div class="modal fade" id="addTimeModal" tabindex="-1">
-  <div class="modal-dialog modal-dialog-centered">
-    <form method="POST" action="/add">
-      <div class="modal-content">
-        <div class="modal-header"><h5 class="modal-title">Add Time Entry</h5></div>
-        <div class="modal-body">
-            <input name="name" class="form-control mb-2" placeholder="Your Name" required>
-            <input type="hidden" name="date">
-            <input name="from_time" type="time" class="form-control mb-2" required>
-            <input name="to_time" type="time" class="form-control mb-2" required>
-            <input name="task" class="form-control mb-2" placeholder="Task Name" required>
-            <textarea name="description" class="form-control mb-2" placeholder="Description" rows="3" required></textarea>
-        </div>
-        <div class="modal-footer">
-            <button type="submit" class="btn btn-primary">Submit</button>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-    const nameField = document.querySelector('input[name="name"]');
+    const form = document.getElementById('entry-form');
+    const nameField = form.querySelector('input[name="name"]');
     let storedName = localStorage.getItem('name');
     if (!storedName) {
         storedName = prompt('Please enter your name:');
-        if (storedName) {
-            localStorage.setItem('name', storedName);
-        }
+        if (storedName) localStorage.setItem('name', storedName);
     }
-    if (storedName && nameField) {
-        nameField.value = storedName;
-    }
-    if (nameField) {
-        nameField.addEventListener('change', () => {
-            localStorage.setItem('name', nameField.value);
-        });
-    }
+    if (storedName) nameField.value = storedName;
+    nameField.addEventListener('change', () => localStorage.setItem('name', nameField.value));
 
-    const fromField = document.querySelector('input[name="from_time"]');
-    const toField = document.querySelector('input[name="to_time"]');
-    const dateField = document.querySelector('input[name="date"]');
-    const modal = document.getElementById('addTimeModal');
     const setCurrentTime = () => {
         const now = new Date();
         const pad = n => n.toString().padStart(2, '0');
         const timeString = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
         const dateString = now.toLocaleDateString('en-CA');
-        if (fromField) fromField.value = timeString;
-        if (toField) toField.value = timeString;
-        if (dateField) dateField.value = dateString;
+        form.querySelector('input[name="from_time"]').value = timeString;
+        form.querySelector('input[name="to_time"]').value = timeString;
+        form.querySelector('input[name="date"]').value = dateString;
     };
-    if (modal) {
-        modal.addEventListener('show.bs.modal', setCurrentTime);
-    } else {
-        setCurrentTime();
-    }
+    setCurrentTime();
+
+    form.addEventListener('submit', function(e){
+        e.preventDefault();
+        const data = new FormData(form);
+        fetch('/add', {method: 'POST', body: data, headers: {'X-Requested-With': 'XMLHttpRequest'}})
+            .then(r => r.json())
+            .then(row => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${row.name}</td>`+
+                    `<td>${row.date_display}</td>`+
+                    `<td>${row.from_time}</td>`+
+                    `<td>${row.to_time}</td>`+
+                    `<td>${row.hours.toFixed(2)}</td>`+
+                    `<td>${row.task}</td>`+
+                    `<td>${row.description_html}</td>`+
+                    `<td>${row.file_link}</td>`;
+                document.getElementById('entry-body').appendChild(tr);
+                form.reset();
+                if (storedName) nameField.value = storedName;
+                setCurrentTime();
+            });
+    });
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add upload folder and ignore it in git
- allow uploading files and convert URLs to links
- rewrite index page with inline entry form
- dynamically append new entries via AJAX
- weekly labels now use MM/DD format
- export CSV with task length and attachments

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b9418de2c8328ba02dbda7c95a632