### PR TITLE
Enhance time tracker features

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from flask import (
     send_file,
     jsonify,
     send_from_directory,
+    abort,
 )
 from werkzeug.utils import secure_filename
 
@@ -36,6 +37,8 @@ if not os.path.exists(CSV_FILE):
             'Task',
             'Description',
             'File',
+            'Completed',
+            'Created At',
         ])
 
 def _read_entries():
@@ -49,6 +52,10 @@ def _read_entries():
                     row['File'] = ''
                 if 'Description' not in row:
                     row['Description'] = ''
+                if 'Completed' not in row:
+                    row['Completed'] = '1'
+                if 'Created At' not in row:
+                    row['Created At'] = datetime.now().isoformat()
                 entries.append(row)
     return entries
 
@@ -74,20 +81,30 @@ def _weekly_summary(entries):
         weekly[key][row['Name']] += _hours(row['From Time'], row['To Time'])
     return weekly
 
+def _daily_summary(entries):
+    daily = defaultdict(lambda: defaultdict(float))
+    for row in entries:
+        daily[row['Date']][row['Name']] += _hours(row['From Time'], row['To Time'])
+    return daily
+
 
 @app.route('/')
 def index():
     entries = _read_entries()
     years = {datetime.strptime(e['Date'], '%Y-%m-%d').year for e in entries}
     show_year = any(year != 2025 for year in years)
-    for e in entries:
+    for i, e in enumerate(entries):
+        e['index'] = i
         e['hours'] = _hours(e['From Time'], e['To Time'])
+        hrs = int(e['hours'])
+        mins = int(round((e['hours'] - hrs) * 60))
+        e['duration_str'] = f"{hrs}h {mins}m"
         e['date_display'] = _format_date(e['Date'], show_year)
     return render_template('index.html', data=entries, show_year=show_year)
 
 @app.route('/add', methods=['POST'])
 def add():
-    today = datetime.now().strftime('%Y-%m-%d')
+    today = request.form.get('date', datetime.now().strftime('%Y-%m-%d'))
     uploaded = request.files.get('file')
     filename = ''
     if uploaded and uploaded.filename:
@@ -96,6 +113,8 @@ def add():
         path = os.path.join(UPLOAD_FOLDER, fname)
         uploaded.save(path)
         filename = fname
+    entries = _read_entries()
+    index = len(entries)
     row = [
         request.form['name'],
         today,
@@ -104,6 +123,8 @@ def add():
         request.form['task'],
         request.form.get('description', ''),
         filename,
+        request.form.get('completed', '1'),
+        datetime.now().isoformat(),
     ]
     with open(CSV_FILE, 'a', newline='') as file:
         writer = csv.writer(file)
@@ -118,9 +139,12 @@ def add():
                 'name': row[0],
                 'date_display': _format_date(row[1], show_year),
                 'hours': hours,
+                'duration_str': f"{int(hours)}h {int(round((hours-int(hours))*60))}m",
                 'task': row[4],
                 'description_html': _linkify(row[5]),
                 'file_link': f'<a href="/uploads/{filename}" download target="_blank">{filename}</a>' if filename else '',
+                'completed': row[7],
+                'index': index,
             }
         )
 
@@ -141,6 +165,14 @@ def weekly_data():
     names = sorted({name for w in weekly.values() for name in w.keys()})
     hours = {name: [weekly[w].get(name, 0) for w in weeks] for name in names}
     return jsonify({'weeks': labels, 'names': names, 'hours': hours})
+
+@app.route('/daily-data')
+def daily_data():
+    daily = _daily_summary(_read_entries())
+    dates = sorted(daily.keys())
+    names = sorted({n for d in daily.values() for n in d.keys()})
+    hours = {name: [daily[date].get(name, 0) for date in dates] for name in names}
+    return jsonify({'dates': dates, 'names': names, 'hours': hours})
 
 @app.route('/download')
 def download():
@@ -188,6 +220,32 @@ def weekly_download():
 @app.route('/uploads/<path:filename>')
 def uploaded(filename):
     return send_from_directory(UPLOAD_FOLDER, filename, as_attachment=True)
+
+@app.route('/edit/<int:index>', methods=['GET', 'POST'])
+def edit(index):
+    entries = _read_entries()
+    if index < 0 or index >= len(entries):
+        abort(404)
+    row = entries[index]
+    created = datetime.fromisoformat(row.get('Created At', datetime.now().isoformat()))
+    if datetime.now() - created > timedelta(hours=24):
+        flash('Editing period expired')
+        return redirect(url_for('index'))
+    if request.method == 'POST':
+        row['Date'] = request.form['date']
+        row['From Time'] = request.form['from_time']
+        row['To Time'] = request.form['to_time']
+        row['Task'] = request.form['task']
+        row['Description'] = request.form.get('description', '')
+        row['Completed'] = request.form.get('completed', '1')
+        entries[index] = row
+        with open(CSV_FILE, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=entries[0].keys())
+            writer.writeheader()
+            writer.writerows(entries)
+        flash('Entry updated')
+        return redirect(url_for('index'))
+    return render_template('edit.html', row=row, index=index)
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))

--- a/static/style.css
+++ b/static/style.css
@@ -25,6 +25,10 @@ body {
     background-color: #fff;
 }
 
+td {
+    white-space: pre-wrap;
+}
+
 .modal-header,
 .modal-footer {
     border: none;

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Edit Entry</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/pulse/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-4">
+    <h3>Edit Entry</h3>
+    <form method="post" class="row g-2" enctype="multipart/form-data">
+        <div class="col-md-3">
+            <label class="form-label">Date</label>
+            <input type="date" name="date" class="form-control" value="{{ row['Date'] }}" required>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">From</label>
+            <input type="time" name="from_time" class="form-control" value="{{ row['From Time'] }}" required>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">To</label>
+            <input type="time" name="to_time" class="form-control" value="{{ row['To Time'] }}" required>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">Task</label>
+            <input name="task" class="form-control" value="{{ row['Task'] }}" required>
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">Description</label>
+            <textarea name="description" class="form-control" rows="2">{{ row['Description'] }}</textarea>
+            <div class="form-check mt-1">
+                <input class="form-check-input" type="checkbox" name="completed" id="edit-completed" {% if row['Completed']=='1' %}checked{% endif %}>
+                <label class="form-check-label" for="edit-completed">Completed</label>
+            </div>
+        </div>
+        <div class="col-12 d-grid">
+            <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+    </form>
+    <a href="/" class="btn btn-link mt-3">Back</a>
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,15 +22,38 @@
 <div class="container mt-4">
     <div class="card p-3 mb-4">
     <form id="entry-form" class="row g-2 align-items-end" enctype="multipart/form-data">
-        <div class="col-md-2"><input name="name" class="form-control" placeholder="Name" required></div>
-        <div class="col-md-2"><input name="from_time" type="time" class="form-control" required></div>
-        <div class="col-md-2"><input name="to_time" type="time" class="form-control" required></div>
-        <div class="col-md-2"><input name="task" class="form-control" placeholder="Task" required></div>
-        <div class="col-md-3">
-            <textarea name="description" class="form-control" placeholder="Description" rows="1"></textarea>
-            <input type="file" name="file" class="form-control mt-1">
+        <div class="col-md-2">
+            <label class="form-label">Name</label>
+            <input name="name" class="form-control" required>
         </div>
-        <div class="col-md-1 d-grid"><button type="submit" class="btn btn-primary">Add</button></div>
+        <div class="col-md-2">
+            <label class="form-label">Date</label>
+            <input name="date" type="date" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">From</label>
+            <input name="from_time" type="time" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">To</label>
+            <input name="to_time" type="time" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Task</label>
+            <input name="task" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Description</label>
+            <textarea name="description" class="form-control" rows="1"></textarea>
+            <input type="file" name="file" class="form-control mt-1">
+            <div class="form-check mt-1">
+                <input class="form-check-input" type="checkbox" name="completed" id="completed" checked>
+                <label class="form-check-label" for="completed">Completed</label>
+            </div>
+        </div>
+        <div class="col-md-1 d-grid">
+            <button type="submit" class="btn btn-primary mt-3">Add</button>
+        </div>
     </form>
     </div>
     <table class="table table-bordered table-striped">
@@ -38,10 +61,12 @@
             <tr>
                 <th>Name</th>
                 <th>Date</th>
-                <th>Hours</th>
+                <th>Duration</th>
                 <th>Task</th>
                 <th>Description</th>
                 <th>File</th>
+                <th>Completed</th>
+                <th></th>
             </tr>
         </thead>
         <tbody id="entry-body">
@@ -49,10 +74,12 @@
             <tr>
                 <td>{{ row['Name'] }}</td>
                 <td>{{ row.date_display }}</td>
-                <td>{{ row.hours | round(2) }}</td>
+                <td>{{ row.duration_str }}</td>
                 <td>{{ row['Task'] }}</td>
                 <td>{{ row['Description']|linkify|safe }}</td>
                 <td>{% if row['File'] %}<a href="/uploads/{{ row['File'] }}" target="_blank" download>{{ row['File'] }}</a>{% endif %}</td>
+                <td>{{ 'Yes' if row['Completed'] == '1' else 'No' }}</td>
+                <td><a href="/edit/{{ row.index }}" class="btn btn-sm btn-secondary">Edit</a></td>
             </tr>
         {% endfor %}
         </tbody>
@@ -74,11 +101,24 @@ document.addEventListener('DOMContentLoaded', function () {
     const setCurrentTime = () => {
         const now = new Date();
         const pad = n => n.toString().padStart(2, '0');
+        form.querySelector('input[name="date"]').value = now.toISOString().slice(0,10);
         const timeString = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
         form.querySelector('input[name="from_time"]').value = timeString;
-        form.querySelector('input[name="to_time"]').value = timeString;
+        const later = new Date(now.getTime() + 15*60000);
+        const laterStr = `${pad(later.getHours())}:${pad(later.getMinutes())}`;
+        form.querySelector('input[name="to_time"]').value = laterStr;
+    };
+    const adjustEndTime = () => {
+        const val = form.querySelector('input[name="from_time"]').value;
+        if (!val) return;
+        const [h, m] = val.split(':').map(Number);
+        const dt = new Date();
+        dt.setHours(h, m + 15);
+        const pad = n => n.toString().padStart(2, '0');
+        form.querySelector('input[name="to_time"]').value = `${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
     };
     setCurrentTime();
+    form.querySelector('input[name="from_time"]').addEventListener('change', adjustEndTime);
 
     form.addEventListener('submit', function(e){
         e.preventDefault();
@@ -89,10 +129,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 const tr = document.createElement('tr');
                 tr.innerHTML = `<td>${row.name}</td>`+
                     `<td>${row.date_display}</td>`+
-                    `<td>${row.hours.toFixed(2)}</td>`+
+                    `<td>${row.duration_str}</td>`+
                     `<td>${row.task}</td>`+
                     `<td>${row.description_html}</td>`+
-                    `<td>${row.file_link}</td>`;
+                    `<td>${row.file_link}</td>`+
+                    `<td>${row.completed === '1' ? 'Yes' : 'No'}</td>`+
+                    `<td><a href="/edit/${row.index}" class="btn btn-sm btn-secondary">Edit</a></td>`;
                 document.getElementById('entry-body').appendChild(tr);
                 form.reset();
                 if (storedName) nameField.value = storedName;

--- a/templates/report.html
+++ b/templates/report.html
@@ -22,10 +22,22 @@
 <div class="container mt-4">
     <h2>Weekly Time Report</h2>
     <canvas id="weekly-chart" width="400" height="200"></canvas>
+    <div class="row mt-3">
+        <div class="col-md-3">
+            <label class="form-label">Person</label>
+            <select id="person-filter" class="form-select"><option value="">-- Select --</option></select>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label">Day</label>
+            <select id="day-filter" class="form-select"><option value="">-- Select --</option></select>
+        </div>
+    </div>
+    <div id="summary" class="mt-3"></div>
     <a href="/weekly-download" class="btn btn-success mt-3">Download Weekly CSV</a>
     <a href="/" class="btn btn-secondary mt-3">Back to Log</a>
 </div>
 <script>
+let weeklyData, dailyData;
 fetch('/weekly-data').then(res => res.json()).then(data => {
     const ctx = document.getElementById('weekly-chart').getContext('2d');
     const labels = data.weeks;
@@ -43,6 +55,50 @@ fetch('/weekly-data').then(res => res.json()).then(data => {
             scales: { x: { stacked: true }, y: { stacked: true } }
         }
     });
+    weeklyData = data;
+    const personSelect = document.getElementById('person-filter');
+    data.names.forEach(n => {
+        const opt = document.createElement('option');
+        opt.value = n; opt.textContent = n; personSelect.appendChild(opt);
+    });
+});
+
+fetch('/daily-data').then(r=>r.json()).then(d => {
+    dailyData = d;
+    const daySel = document.getElementById('day-filter');
+    d.dates.forEach(date => {
+        const opt = document.createElement('option');
+        opt.value = date; opt.textContent = date; daySel.appendChild(opt);
+    });
+});
+
+const summary = document.getElementById('summary');
+document.getElementById('person-filter').addEventListener('change', e => {
+    if(!weeklyData) return;
+    const name = e.target.value;
+    if(!name) { summary.textContent=''; return; }
+    const idx = weeklyData.names.indexOf(name);
+    let html = '<h5>Weekly Hours for '+name+'</h5><ul>';
+    weeklyData.weeks.forEach((week,i)=>{
+        const h = weeklyData.hours[name][i] || 0;
+        html += `<li>${week}: ${h.toFixed(2)}h ${h>=40?'✓':'✗'}</li>`;
+    });
+    html += '</ul>';
+    summary.innerHTML = html;
+});
+
+document.getElementById('day-filter').addEventListener('change', e => {
+    if(!dailyData) return;
+    const day = e.target.value;
+    if(!day) { summary.textContent=''; return; }
+    const idx = dailyData.dates.indexOf(day);
+    let html = '<h5>Hours on '+day+'</h5><ul>';
+    dailyData.names.forEach(n => {
+        const h = dailyData.hours[n][idx] || 0;
+        html += `<li>${n}: ${h.toFixed(2)}h ${h>=8?'✓':'✗'}</li>`;
+    });
+    html += '</ul>';
+    summary.innerHTML = html;
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add new fields for completion and creation timestamp
- support editing entries within 24 hours
- show task duration, completed status and edit links on main page
- default end time 15 minutes after start
- add filters in weekly report for name/day with 8/40 hour checks
- style table cells to wrap text

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bd4b123d48328a6577acf09c970b0