### PR TITLE
Fix accordion toggle and date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ client-side with Chart.js. All entries are written to and read from
 - Inline editing popup
 - CSV download (raw + weekly)
 - Sharp Economy branding
+- Simple, CSV-only storage without a "Completed" column
 
 ## File Structure
 ```

--- a/app.py
+++ b/app.py
@@ -31,7 +31,6 @@ FIELDNAMES = [
     'Task',
     'Description',
     'File',
-    'Completed',
     'Created At',
 ]
 
@@ -69,8 +68,7 @@ def _ensure_csv():
             'To Time': row[3] if len(row) > 3 else '',
             'Task': task,
             'Description': desc,
-            'File': '',
-            'Completed': '1',
+            'File': row[6] if len(row) > 6 else '',
             'Created At': datetime.now().isoformat(),
         })
     with open(CSV_FILE, 'w', newline='') as f:
@@ -87,7 +85,6 @@ def _map_row(row: dict) -> dict:
         'task': 'Task',
         'description': 'Description',
         'file': 'File',
-        'completed': 'Completed',
         'created_at': 'Created At',
         'created at': 'Created At',
     }
@@ -113,8 +110,6 @@ def _read_entries():
                     row['File'] = ''
                 if 'Description' not in row:
                     row['Description'] = ''
-                if 'Completed' not in row:
-                    row['Completed'] = '1'
                 if 'Created At' not in row:
                     row['Created At'] = datetime.now().isoformat()
                 entries.append(row)
@@ -124,8 +119,17 @@ def _hours(from_t, to_t):
     fmt = '%H:%M'
     return (datetime.strptime(to_t, fmt) - datetime.strptime(from_t, fmt)).seconds / 3600
 
+def _parse_date(date_str):
+    try:
+        return datetime.strptime(date_str, '%Y-%m-%d')
+    except ValueError:
+        try:
+            return datetime.fromisoformat(date_str)
+        except ValueError:
+            return datetime.now()
+
 def _format_date(date_str, show_year=False):
-    dt = datetime.strptime(date_str, '%Y-%m-%d')
+    dt = _parse_date(date_str)
     return dt.strftime('%m/%d/%Y' if show_year else '%m/%d')
 
 @app.template_filter('linkify')
@@ -136,7 +140,7 @@ def _linkify(text):
 def _weekly_summary(entries):
     weekly = defaultdict(lambda: defaultdict(float))
     for row in entries:
-        dt = datetime.strptime(row['Date'], '%Y-%m-%d')
+        dt = _parse_date(row['Date'])
         week_start = dt - timedelta(days=dt.weekday())
         key = week_start.strftime('%Y-%m-%d')
         weekly[key][row['Name']] += _hours(row['From Time'], row['To Time'])
@@ -152,7 +156,7 @@ def _weekday_summary(entries):
     days = defaultdict(lambda: defaultdict(float))
     labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
     for row in entries:
-        dt = datetime.strptime(row['Date'], '%Y-%m-%d')
+        dt = _parse_date(row['Date'])
         key = labels[dt.weekday()]
         days[key][row['Name']] += _hours(row['From Time'], row['To Time'])
     return days
@@ -161,7 +165,7 @@ def _weekday_summary(entries):
 @app.route('/')
 def index():
     entries = _read_entries()
-    years = {datetime.strptime(e['Date'], '%Y-%m-%d').year for e in entries}
+    years = {_parse_date(e['Date']).year for e in entries}
     show_year = any(year != 2025 for year in years)
     for i, e in enumerate(entries):
         e['index'] = i
@@ -211,7 +215,6 @@ def add():
         'Task': request.form['task'],
         'Description': request.form.get('description', ''),
         'File': filename,
-        'Completed': request.form.get('completed', '1'),
         'Created At': datetime.now().isoformat(),
     }
     with open(CSV_FILE, 'a', newline='') as file:
@@ -220,7 +223,7 @@ def add():
 
     if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         hours = _hours(row['From Time'], row['To Time'])
-        years = {datetime.strptime(r['Date'], '%Y-%m-%d').year for r in _read_entries()}
+        years = {_parse_date(r['Date']).year for r in _read_entries()}
         show_year = any(y != 2025 for y in years)
         return jsonify(
             {
@@ -231,7 +234,6 @@ def add():
                 'task': row['Task'],
                 'description_html': _linkify(row['Description']),
                 'file_link': f'<a href="/uploads/{filename}" download target="_blank">{filename}</a>' if filename else '',
-                'completed': row['Completed'],
                 'index': index,
             }
         )
@@ -247,7 +249,7 @@ def report():
 def weekly_data():
     weekly = _weekly_summary(_read_entries())
     weeks = sorted(weekly.keys())
-    years = {datetime.strptime(w, '%Y-%m-%d').year for w in weeks}
+    years = {_parse_date(w).year for w in weeks}
     show_year = any(y != 2025 for y in years)
     labels = [_format_date(w, show_year) for w in weeks]
     names = sorted({name for w in weekly.values() for name in w.keys()})
@@ -301,7 +303,7 @@ def download():
 def weekly_download():
     weekly = _weekly_summary(_read_entries())
     weeks = sorted(weekly.keys())
-    years = {datetime.strptime(w, '%Y-%m-%d').year for w in weeks}
+    years = {_parse_date(w).year for w in weeks}
     show_year = any(y != 2025 for y in years)
     labels = [_format_date(w, show_year) for w in weeks]
     names = sorted({name for w in weekly.values() for name in w.keys()})
@@ -342,7 +344,6 @@ def edit(index):
         row['To Time'] = request.form['to_time']
         row['Task'] = request.form['task']
         row['Description'] = request.form.get('description', '')
-        row['Completed'] = request.form.get('completed', '1')
         entries[index] = row
         with open(CSV_FILE, 'w', newline='') as f:
             writer = csv.DictWriter(f, fieldnames=FIELDNAMES)

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -3,6 +3,7 @@
 <head>
     <title>Edit Entry</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/pulse/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body>
 <div class="container mt-4">
@@ -27,10 +28,6 @@
         <div class="col-md-6">
             <label class="form-label">Description</label>
             <textarea name="description" class="form-control" rows="2">{{ row['Description'] }}</textarea>
-            <div class="form-check mt-1">
-                <input class="form-check-input" type="checkbox" name="completed" id="edit-completed" {% if row['Completed']=='1' %}checked{% endif %}>
-                <label class="form-check-label" for="edit-completed">Completed</label>
-            </div>
         </div>
         <div class="col-12 d-grid">
             <button type="submit" class="btn btn-primary">Save</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/pulse/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <link rel="stylesheet" href="/static/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
@@ -23,7 +24,7 @@
 
 <div class="container mt-4">
     <div class="card p-4 mb-4">
-    <form id="entry-form" class="row g-3" enctype="multipart/form-data">
+    <form id="entry-form" class="row g-3 align-items-end" enctype="multipart/form-data">
         <div class="col-md-2">
             <label class="form-label">Name</label>
             <input name="name" class="form-control" required>
@@ -51,13 +52,9 @@
                 <button type="button" class="btn btn-outline-secondary attach-btn"><i class="bi bi-paperclip"></i></button>
             </div>
             <input type="file" name="file" id="file-input" class="d-none">
-            <div class="form-check mt-1">
-                <input class="form-check-input" type="checkbox" name="completed" id="completed" checked>
-                <label class="form-check-label" for="completed">Completed</label>
-            </div>
         </div>
-        <div class="col-md-1 d-grid">
-            <button type="submit" class="btn btn-primary mt-3">Add</button>
+        <div class="col-md-1 d-grid align-self-end">
+            <button type="submit" class="btn btn-primary">Add</button>
         </div>
     </form>
     </div>
@@ -82,7 +79,6 @@
                                 <th>Task</th>
                                 <th>Description</th>
                                 <th>File</th>
-                                <th>Completed</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -95,7 +91,6 @@
                                 <td>{{ row['Task'] }}</td>
                                 <td>{{ row['Description']|linkify|safe }}</td>
                                 <td>{% if row['File'] %}<a href="/uploads/{{ row['File'] }}" target="_blank" download>{{ row['File'] }}</a>{% endif %}</td>
-                                <td>{{ 'Yes' if row['Completed']=='1' else 'No' }}</td>
                                 <td><button class="btn btn-sm btn-secondary edit-btn" data-index="{{ row.index }}">Edit</button></td>
                             </tr>
                         {% endfor %}
@@ -138,10 +133,6 @@
               <div class="col-md-6">
                 <label class="form-label">Description</label>
                 <textarea name="description" class="form-control" rows="2"></textarea>
-                <div class="form-check mt-1">
-                  <input class="form-check-input" type="checkbox" name="completed" id="edit-completed">
-                  <label class="form-check-label" for="edit-completed">Completed</label>
-                </div>
               </div>
             </div>
             <div class="modal-footer">
@@ -210,7 +201,6 @@ document.addEventListener('DOMContentLoaded', function(){
                     editForm.to_time.value = row['To Time'];
                     editForm.task.value = row.Task;
                     editForm.description.value = row.Description;
-                    editForm.completed.checked = row.Completed === '1';
                     editModal.show();
                 });
         });

--- a/templates/report.html
+++ b/templates/report.html
@@ -3,6 +3,7 @@
 <head>
     <title>Weekly Report</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/pulse/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- drop Completed column from all logic and convert old CSV automatically
- parse dates safely via `_parse_date`
- align add form inputs in one row and keep Add button inline
- include Bootstrap JS bundle so accordion collapses
- document the Completed column removal in README

## Testing
- `python -m compileall -q app.py templates/*.html static/*.css`


------
https://chatgpt.com/codex/tasks/task_e_686d3112fd4c8328bc6b2bf650079dbd