### PR TITLE
Display hours as HH:MM

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,6 +170,7 @@ def index():
         hrs = int(e['hours'])
         mins = int(round((e['hours'] - hrs) * 60))
         e['duration_str'] = f"{hrs}h {mins}m"
+        e['duration_hm'] = f"{hrs}:{mins:02d}"
         e['date_display'] = _format_date(e['Date'], show_year)
 
     grouped = defaultdict(list)
@@ -228,6 +229,7 @@ def add():
                 'date_display': _format_date(row['Date'], show_year),
                 'hours': hours,
                 'duration_str': f"{int(hours)}h {int(round((hours-int(hours))*60))}m",
+                'duration_hm': f"{int(hours)}:{int(round((hours-int(hours))*60)):02d}",
                 'task': row['Task'],
                 'description_html': _linkify(row['Description']),
                 'file_link': f'<a href="/uploads/{filename}" download target="_blank">{filename}</a>' if filename else '',

--- a/templates/index.html
+++ b/templates/index.html
@@ -87,7 +87,7 @@
                             <tr>
                                 <td>{{ row['Name'] }}</td>
                                 <td>{{ row['From Time'] }}-{{ row['To Time'] }}</td>
-                                <td>{{ '%.2f'|format(row.hours) }}</td>
+                                <td>{{ row.duration_hm }}</td>
                                 <td>{{ row['Task'] }}</td>
                                 <td>{{ row['Description']|linkify|safe }}</td>
                                 <td>{% if row['File'] %}<a href="/uploads/{{ row['File'] }}" target="_blank" download>{{ row['File'] }}</a>{% endif %}</td>


### PR DESCRIPTION
## Summary
- display hours in HH:MM format on the home page
- include HH:MM duration in the JSON response for adding entries

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d52a4282c8328aecc51f2b94f9a41