### PR TITLE
Display hours as HH:MM

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,6 +106,7 @@ def _read_entries():
                     row['Description'] = ''
                 if 'Created At' not in row:
                     row['Created At'] = datetime.now().isoformat()
+                row['Date'] = _canonical_date(row['Date'])
                 entries.append(row)
     return entries
 
@@ -124,6 +125,9 @@ def _parse_date(date_str):
         return datetime.fromisoformat(date_str)
     except ValueError:
         return datetime.now()
+
+def _canonical_date(date_str):
+    return _parse_date(date_str).strftime('%Y-%m-%d')
 
 def _format_date(date_str, show_year=False):
     dt = _parse_date(date_str)
@@ -146,7 +150,8 @@ def _weekly_summary(entries):
 def _daily_summary(entries):
     daily = defaultdict(lambda: defaultdict(float))
     for row in entries:
-        daily[row['Date']][row['Name']] += _hours(row['From Time'], row['To Time'])
+        key = _canonical_date(row['Date'])
+        daily[key][row['Name']] += _hours(row['From Time'], row['To Time'])
     return daily
 
 def _weekday_summary(entries):
@@ -170,12 +175,14 @@ def index():
         hrs = int(e['hours'])
         mins = int(round((e['hours'] - hrs) * 60))
         e['duration_str'] = f"{hrs}h {mins}m"
+        e['duration_hm'] = f"{hrs}:{mins:02d}"
         e['date_display'] = _format_date(e['Date'], show_year)
 
     grouped = defaultdict(list)
     totals = {}
     for e in entries:
-        grouped[e['Date']].append(e)
+        key = _canonical_date(e['Date'])
+        grouped[key].append(e)
     for date, rows in grouped.items():
         per = defaultdict(float)
         for r in rows:
@@ -194,6 +201,7 @@ def index():
 @app.route('/add', methods=['POST'])
 def add():
     today = request.form.get('date', datetime.now().strftime('%Y-%m-%d'))
+    today = _canonical_date(today)
     uploaded = request.files.get('file')
     filename = ''
     if uploaded and uploaded.filename:
@@ -228,6 +236,7 @@ def add():
                 'date_display': _format_date(row['Date'], show_year),
                 'hours': hours,
                 'duration_str': f"{int(hours)}h {int(round((hours-int(hours))*60))}m",
+                'duration_hm': f"{int(hours)}:{int(round((hours-int(hours))*60)):02d}",
                 'task': row['Task'],
                 'description_html': _linkify(row['Description']),
                 'file_link': f'<a href="/uploads/{filename}" download target="_blank">{filename}</a>' if filename else '',
@@ -336,7 +345,7 @@ def edit(index):
         flash('Editing period expired')
         return redirect(url_for('index'))
     if request.method == 'POST':
-        row['Date'] = request.form['date']
+        row['Date'] = _canonical_date(request.form['date'])
         row['From Time'] = request.form['from_time']
         row['To Time'] = request.form['to_time']
         row['Task'] = request.form['task']

--- a/templates/index.html
+++ b/templates/index.html
@@ -87,7 +87,7 @@
                             <tr>
                                 <td>{{ row['Name'] }}</td>
                                 <td>{{ row['From Time'] }}-{{ row['To Time'] }}</td>
-                                <td>{{ '%.2f'|format(row.hours) }}</td>
+                                <td>{{ row.duration_hm }}</td>
                                 <td>{{ row['Task'] }}</td>
                                 <td>{{ row['Description']|linkify|safe }}</td>
                                 <td>{% if row['File'] %}<a href="/uploads/{{ row['File'] }}" target="_blank" download>{{ row['File'] }}</a>{% endif %}</td>


### PR DESCRIPTION
## Summary
- display hours in HH:MM format on the home page
- include HH:MM duration in the JSON response for adding entries
- normalize dates so entries for the same day are grouped together

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686d52a4282c8328aecc51f2b94f9a41