### PR TITLE
Fix psycopg2 import error on Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Time Tracker App (Render-Ready)
 
 This is a lightweight Flask time tracking app that stores entries in a
-PostgreSQL table on Supabase using `psycopg2`. Column names may use spaces
+PostgreSQL table on Supabase using `psycopg`. Column names may use spaces
 (e.g. `"From Time"`) or snake case (e.g. `from_time`)—the app converts them
 automatically. Charts are rendered client-side with Chart.js.
 
@@ -14,7 +14,7 @@ automatically. Charts are rendered client-side with Chart.js.
 - Inline editing popup
 - CSV download (raw + weekly)
 - Sharp Economy branding
-- Stores data in a Supabase PostgreSQL table via `psycopg2`
+- Stores data in a Supabase PostgreSQL table via `psycopg`
 
 ## File Structure
 ```

--- a/app.py
+++ b/app.py
@@ -17,8 +17,8 @@ from flask import (
     abort,
 )
 from werkzeug.utils import secure_filename
-import psycopg2
-from psycopg2.extras import RealDictCursor
+import psycopg
+from psycopg.rows import dict_row
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "replace-me")
@@ -42,7 +42,7 @@ TABLE_NAME = 'time_entries'
 def get_conn():
     if not DB_URL:
         return None
-    return psycopg2.connect(DB_URL)
+    return psycopg.connect(DB_URL)
 
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
@@ -72,7 +72,7 @@ def _map_row(row: dict) -> dict:
 def _read_entries():
     if DB_URL:
         with get_conn() as conn:
-            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            with conn.cursor(row_factory=dict_row) as cur:
                 cur.execute(f"SELECT * FROM {TABLE_NAME} ORDER BY date, from_time")
                 rows = cur.fetchall()
 

--- a/migrate_to_supabase.py
+++ b/migrate_to_supabase.py
@@ -1,7 +1,7 @@
 import os
 import csv
 from datetime import datetime
-import psycopg2
+import psycopg
 
 DB_URL = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
 if not DB_URL:
@@ -9,7 +9,7 @@ if not DB_URL:
 
 TABLE = "time_entries"
 
-with psycopg2.connect(DB_URL) as conn:
+with psycopg.connect(DB_URL) as conn:
     with conn.cursor() as cur:
         cur.execute(
             f"""
@@ -42,7 +42,7 @@ def parse_date(s: str) -> str:
         return datetime.now().date().isoformat()
 
 
-with psycopg2.connect(DB_URL) as conn:
+with psycopg.connect(DB_URL) as conn:
     with conn.cursor() as cur:
         with open("time_log.csv", newline="") as f:
             reader = csv.DictReader(f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask==2.3.3
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.9


### PR DESCRIPTION
## Summary
- switch to psycopg3 which has wheels for Python 3.13
- update imports for psycopg3

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py migrate_to_supabase.py`
- `python app.py` (started dev server)

------
https://chatgpt.com/codex/tasks/task_e_686e327c3f148328b34f680a6a372450