### PR TITLE
Fix Firestore query ordering for fields with spaces

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ def _read_entries():
         firestore.client()
         .collection('time_entries')
         .order_by('Date')
-        .order_by(field_path.FieldPath('From Time'))
+        .order_by(field_path.FieldPath('From Time').to_api_repr())
         .stream()
     )
     entries = []


### PR DESCRIPTION
## Summary
- handle spaces in field names when ordering Firestore queries

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e53a6e96c83288b10c3b3cfa0da74